### PR TITLE
Disable certain drops from plants (configurable)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,11 @@ dependencies {
     compileOnly("org.projectlombok:lombok:1.18.30")
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("com.zaxxer:HikariCP:6.2.1")
-    implementation("eu.okaeri:okaeri-configs-yaml-bukkit:5.0.8")
+    implementation("eu.okaeri:okaeri-configs-yaml-bukkit:5.0.9")
+    implementation("eu.okaeri:okaeri-configs-serdes-bukkit:5.0.9")
+
     implementation("dev.thorinwasher.schem:schem-reader:1.0.0")
-    implementation("com.github.Thorinwasher:BlockUtil:v2.1.0")
+    implementation("com.github.Thorinwasher.BlockUtil:blockutil:main-SNAPSHOT")
 
     compileOnly("org.xerial:sqlite-jdbc:3.47.2.0")
 
@@ -81,10 +83,10 @@ tasks {
         listOf(
             "com.zaxxer.hikari",
             "dev.thorinwasher.schem",
+            "dev.thorinwasher.blockutil",
             "net.kyori.adventure.nbt",
             "net.kyori.examination",
             "org.simpleyaml",
-            "org.yaml.snakeyaml",
             "eu.okaeri.configs"
         ).forEach { relocate(it, "${project.group}.lib.$it") }
     }

--- a/src/main/java/dev/jsinco/brewery/garden/Garden.java
+++ b/src/main/java/dev/jsinco/brewery/garden/Garden.java
@@ -3,21 +3,24 @@ package dev.jsinco.brewery.garden;
 import com.dre.brewery.recipe.PluginItem;
 import dev.jsinco.brewery.garden.commands.GardenCommand;
 import dev.jsinco.brewery.garden.configuration.BreweryGardenConfig;
+import dev.jsinco.brewery.garden.configuration.SerdesGarden;
+import dev.jsinco.brewery.garden.integration.BreweryGardenIngredient;
 import dev.jsinco.brewery.garden.listener.BlockEventListener;
 import dev.jsinco.brewery.garden.listener.EventListeners;
-import dev.jsinco.brewery.garden.integration.BreweryGardenIngredient;
 import dev.jsinco.brewery.garden.persist.Database;
 import dev.jsinco.brewery.garden.persist.GardenPlantDataType;
 import dev.jsinco.brewery.garden.plant.GardenPlant;
 import dev.jsinco.brewery.garden.plant.GrowthManager;
 import dev.jsinco.brewery.garden.plant.PlantType;
+import dev.thorinwasher.blockutil.api.BlockUtilAPI;
+import dev.thorinwasher.blockutil.api.event.BlockDisableDropEvent;
 import eu.okaeri.configs.ConfigManager;
 import eu.okaeri.configs.yaml.bukkit.YamlBukkitConfigurer;
+import eu.okaeri.configs.yaml.bukkit.serdes.SerdesBukkit;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import lombok.Getter;
-import org.bukkit.Bukkit;
-import org.bukkit.NamespacedKey;
-import org.bukkit.World;
+import org.bukkit.*;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -25,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 
 public class Garden extends JavaPlugin {
 
@@ -37,6 +41,8 @@ public class Garden extends JavaPlugin {
     private Database database;
     @Getter
     private GardenPlantDataType gardenPlantDataType;
+    @Getter
+    private BlockUtilAPI blockUtil;
 
     @Override
     public void onLoad() {
@@ -53,7 +59,17 @@ public class Garden extends JavaPlugin {
         }
         gardenRegistry = new PlantRegistry();
         gardenPlantDataType = new GardenPlantDataType(database);
-
+        this.blockUtil = new BlockUtilAPI.Builder()
+                .withConnectionSupplier(() -> {
+                    try {
+                        return database.getConnection();
+                    } catch (SQLException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .withDropEventHandler(this::handleBlockDrops)
+                .withPluginOwner(this)
+                .build();
         try {
             PluginItem.registerForConfig(this.getName(), BreweryGardenIngredient::new);
         } catch (NoClassDefFoundError ignored) {
@@ -71,13 +87,27 @@ public class Garden extends JavaPlugin {
         Bukkit.getScheduler().runTaskTimer(this, new GrowthManager(gardenRegistry, gardenPlantDataType)::tick, 0, 200);
     }
 
+    private void handleBlockDrops(BlockDisableDropEvent blockDisableDropEvent) {
+        Material material = blockDisableDropEvent.getBlock().getType();
+        if (pluginConfiguration.getDropsDefaultItems().stream().anyMatch(tag -> tag.isTagged(material))) {
+            blockDisableDropEvent.setDisableDrops(false);
+            return;
+        }
+        for (Map.Entry<Tag<Material>, Material> entry : pluginConfiguration.getDropOverride().entrySet()) {
+            if (entry.getKey().isTagged(material)) {
+                blockDisableDropEvent.setDropOverride(List.of(new ItemStack(entry.getValue())));
+                return;
+            }
+        }
+    }
+
     public void reload() {
         this.pluginConfiguration = compileConfig();
     }
 
     private BreweryGardenConfig compileConfig() {
         return ConfigManager.create(BreweryGardenConfig.class, it -> {
-            it.withConfigurer(new YamlBukkitConfigurer());
+            it.withConfigurer(new YamlBukkitConfigurer(), new SerdesBukkit(), new SerdesGarden());
             it.withBindFile(new File(this.getDataFolder(), "config.yml"));
             it.saveDefaults();
             it.load(true);

--- a/src/main/java/dev/jsinco/brewery/garden/configuration/BreweryGardenConfig.java
+++ b/src/main/java/dev/jsinco/brewery/garden/configuration/BreweryGardenConfig.java
@@ -1,13 +1,15 @@
 package dev.jsinco.brewery.garden.configuration;
 
+import com.google.common.collect.ImmutableMap;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
-import eu.okaeri.configs.annotation.CustomKey;
 import eu.okaeri.configs.annotation.Header;
 import lombok.Getter;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 
 import java.util.List;
+import java.util.Map;
 
 @Header({
         "Welcome to the configuration file for the BreweryGarden addon!",
@@ -20,11 +22,11 @@ import java.util.List;
 public class BreweryGardenConfig extends OkaeriConfig {
 
     @Comment({"How likely it is for a seed to spawn from a broken 'validSeedDropBlocks' block.",
-    "Use an integer from 1 to 100."})
+            "Use an integer from 1 to 100."})
     private int seedSpawnChance = 15;
 
     @Comment({"The integer which determines if a plant is fully grown (has a plant sprouted on it).",
-    "A plant's growth stage has an 80% chance to increase by '1' every 5 minutes. Making '4' equal one full Minecraft day, or 20 minutes."})
+            "A plant's growth stage has an 80% chance to increase by '1' every 5 minutes. Making '4' equal one full Minecraft day, or 20 minutes."})
     private int fullyGrown = 4;
 
     @Comment("A list of materials which a seed may drop from.")
@@ -35,4 +37,13 @@ public class BreweryGardenConfig extends OkaeriConfig {
 
     @Comment("A list of worlds where the BreweryGarden addon is disabled.")
     private List<String> blacklistedWorlds = List.of("resource", "resource_nether");
+
+    @Comment("A list of tags of materials generated through Garden that will drop when broken")
+    private List<Tag<Material>> dropsDefaultItems = List.of(Tag.LOGS);
+
+    @Comment("A map of tags of materials generated through Garden with custom drops")
+    private Map<Tag<Material>, Material> dropOverride = new ImmutableMap.Builder<Tag<Material>, Material>()
+            .put(Tag.WOODEN_STAIRS, Material.STICK)
+            .put(Tag.WOODEN_TRAPDOORS, Material.STICK)
+            .build();
 }

--- a/src/main/java/dev/jsinco/brewery/garden/configuration/SerdesGarden.java
+++ b/src/main/java/dev/jsinco/brewery/garden/configuration/SerdesGarden.java
@@ -1,0 +1,12 @@
+package dev.jsinco.brewery.garden.configuration;
+
+import eu.okaeri.configs.serdes.OkaeriSerdesPack;
+import eu.okaeri.configs.serdes.SerdesRegistry;
+import lombok.NonNull;
+
+public class SerdesGarden implements OkaeriSerdesPack {
+    @Override
+    public void register(@NonNull SerdesRegistry registry) {
+        registry.register(new TagSerializer());
+    }
+}

--- a/src/main/java/dev/jsinco/brewery/garden/configuration/TagSerializer.java
+++ b/src/main/java/dev/jsinco/brewery/garden/configuration/TagSerializer.java
@@ -1,0 +1,33 @@
+package dev.jsinco.brewery.garden.configuration;
+
+import eu.okaeri.configs.schema.GenericsDeclaration;
+import eu.okaeri.configs.serdes.DeserializationData;
+import eu.okaeri.configs.serdes.ObjectSerializer;
+import eu.okaeri.configs.serdes.SerializationData;
+import lombok.NonNull;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
+
+public class TagSerializer implements ObjectSerializer<Tag<?>> {
+
+    @Override
+    public boolean supports(@NonNull Class<? super Tag<?>> type) {
+        return Tag.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void serialize(@NonNull Tag object, @NonNull SerializationData data, @NonNull GenericsDeclaration generics) {
+        data.setValue("#" + object.key());
+    }
+
+    @Override
+    public Tag<?> deserialize(@NonNull DeserializationData data, @NonNull GenericsDeclaration generics) {
+        String serialized = data.getValue(String.class);
+        if (!serialized.startsWith("#")) {
+            throw new IllegalArgumentException("Expected string to start with '#'");
+        }
+        return Bukkit.getTag(Tag.REGISTRY_BLOCKS, NamespacedKey.fromString(serialized.substring(1)), Material.class);
+    }
+}

--- a/src/main/java/dev/jsinco/brewery/garden/structure/PlantStructure.java
+++ b/src/main/java/dev/jsinco/brewery/garden/structure/PlantStructure.java
@@ -1,5 +1,6 @@
 package dev.jsinco.brewery.garden.structure;
 
+import dev.jsinco.brewery.garden.Garden;
 import dev.thorinwasher.schem.Schematic;
 import org.bukkit.*;
 import org.bukkit.block.data.BlockData;
@@ -53,6 +54,7 @@ public record PlantStructure(Schematic schematic, int originX, int originY, int 
                 return;
             }
             world.setBlockData(posToReplace, blockData);
+            Garden.getInstance().getBlockUtil().disableItemDrops(world.getBlockAt(posToReplace));
         });
     }
 
@@ -67,6 +69,7 @@ public record PlantStructure(Schematic schematic, int originX, int originY, int 
             if (location.getBlock().getType() == blockData.getMaterial()) {
                 location.getBlock().setType(Material.AIR);
             }
+            Garden.getInstance().getBlockUtil().enableItemDrops(world.getBlockAt(location));
         });
     }
 


### PR DESCRIPTION
Disable most block drops from plants, for example all the moss carpets, and leaves, and so on.

Only drops are the logs, and stick for some plank blocks.

This can be changed in the config
